### PR TITLE
Refactor to interface-driven design.

### DIFF
--- a/src/Core/Implementations/Executables/Echo.cs
+++ b/src/Core/Implementations/Executables/Echo.cs
@@ -4,21 +4,30 @@ using Sheller.Models;
 namespace Sheller.Implementations.Executables
 {
     /// <summary>
+    /// The interface for `echo`.
+    /// </summary>
+    public interface IEcho : IExecutable<IEcho, string> {}
+
+    /// <summary>
     /// The executable type for `echo`.
     /// </summary>
-    public class Echo : Executable<Echo, string>
+    public class Echo : Executable<IEcho, string>, IEcho
     {
+        /// <summary>
+        /// Creates a new instance of the <see cref="Sleep"/> type.
+        /// </summary>
+        /// <returns>The instance.</returns>
+        protected override Executable<IEcho> Create() => new Echo();
+
+        /// <summary>
+        /// The <cref see="Sleep"/> constructor.
+        /// </summary>
+        public Echo() : base("echo") {}
+
         /// <summary>
         /// Executes the executable.
         /// </summary>
         /// <returns>A task which results in a <see cref="string"/> (i.e., the result of the execution).</returns>
         public override Task<string> ExecuteAsync() => this.ExecuteAsync(cr => cr.StandardOutput.Trim());
-
-        /// <summary>
-        /// Initializes an <see cref="Echo"/> instance with the provided shell.
-        /// </summary>
-        /// <param name="shell">The shell in which the executable should run.</param>
-        /// <returns>This instance.</returns>
-        public override Echo Initialize(IShell shell) => this.Initialize("echo", shell);
     }
 }

--- a/src/Core/Implementations/Executables/Echo.cs
+++ b/src/Core/Implementations/Executables/Echo.cs
@@ -14,13 +14,13 @@ namespace Sheller.Implementations.Executables
     public class Echo : Executable<IEcho, string>, IEcho
     {
         /// <summary>
-        /// Creates a new instance of the <see cref="Sleep"/> type.
+        /// Creates a new instance of the <see cref="Echo"/> type.
         /// </summary>
         /// <returns>The instance.</returns>
         protected override Executable<IEcho> Create() => new Echo();
 
         /// <summary>
-        /// The <cref see="Sleep"/> constructor.
+        /// The <cref see="Echo"/> constructor.
         /// </summary>
         public Echo() : base("echo") {}
 

--- a/src/Core/Implementations/Executables/Executable.cs
+++ b/src/Core/Implementations/Executables/Executable.cs
@@ -66,7 +66,6 @@ namespace Sheller.Implementations.Executables
         /// Initializes the shell.
         /// </summary>
         /// <param name="executable">The name or path of the executable to run.</param>
-        /// <param name="shell">The shell in which the executable should run.</param>
         public Executable(string executable) => this.Initialize(executable);
 
         /// <summary>
@@ -79,7 +78,6 @@ namespace Sheller.Implementations.Executables
         /// Initializes this instance with the provided shell.
         /// </summary>
         /// <param name="executable">The name or path of the executable to run.</param>
-        /// <param name="shell">The shell in which the executable should run.</param>
         /// <returns>This instance.</returns>
         private IExecutable Initialize(string executable) => Initialize(executable, null, null, null, null, null, null);
         

--- a/src/Core/Implementations/Executables/GenericExe.cs
+++ b/src/Core/Implementations/Executables/GenericExe.cs
@@ -3,10 +3,24 @@ using Sheller.Models;
 namespace Sheller.Implementations.Executables
 {
     /// <summary>
+    /// The interface for a generic executable.
+    /// </summary>
+    public interface IGenericExe : IExecutable {}
+
+    /// <summary>
     /// The executable type for a generic executable.
     /// </summary>
-    public class GenericExe : ExecutableBase<GenericExe>
+    public class GenericExe : Executable<IGenericExe>, IGenericExe
     {
-        
+        /// <summary>
+        /// Creates a new instance of the <see cref="GenericExe"/> type.
+        /// </summary>
+        /// <returns>The instance.</returns>
+        protected override Executable<IGenericExe> Create() => new GenericExe(this.Path);
+
+        /// <summary>
+        /// The <cref see="GenericExe"/> constructor.
+        /// </summary>
+        public GenericExe(string executable) : base(executable) {}
     }
 }

--- a/src/Core/Implementations/Executables/Helm.cs
+++ b/src/Core/Implementations/Executables/Helm.cs
@@ -6,16 +6,37 @@ using Sheller.Models;
 namespace Sheller.Implementations.Executables
 {
     /// <summary>
-    /// The executable type for `helm`.
+    /// The interface for `helm`.
     /// </summary>
-    public class Helm : Executable<Helm>
+    public interface IHelm : IExecutable
     {
         /// <summary>
-        /// Initializes an <see cref="Helm"/> instance with the provided shell.
+        /// Adds a kubeconfig argument to the execution context and returns a `new` context instance.
         /// </summary>
-        /// <param name="shell">The shell in which the executable should run.</param>
-        /// <returns>This instance.</returns>
-        public override Helm Initialize(IShell shell) => this.Initialize("helm", shell);
+        /// <remarks>
+        /// Multiple calls to this method in one execution context will trigger an exception.  It is not required, but convention
+        /// would dictate that this method be called before arguments.
+        /// </remarks>
+        /// <param name="configPath"></param>
+        /// <returns>A `new` instance of <see cref="Helm"/> with the kubeconfig passed to this call.</returns>
+        IHelm WithKubeConfig(string configPath);
+    }
+
+    /// <summary>
+    /// The executable type for `helm`.
+    /// </summary>
+    public class Helm : Executable<IHelm>, IHelm
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="Helm"/> type.
+        /// </summary>
+        /// <returns>The instance.</returns>
+        protected override Executable<IHelm> Create() => new Helm();
+
+        /// <summary>
+        /// The <cref see="Helm"/> constructor.
+        /// </summary>
+        public Helm() : base("helm") {}
 
         /// <summary>
         /// Adds a kubeconfig argument to the execution context and returns a `new` context instance.
@@ -26,12 +47,12 @@ namespace Sheller.Implementations.Executables
         /// </remarks>
         /// <param name="configPath"></param>
         /// <returns>A `new` instance of <see cref="Helm"/> with the kubeconfig passed to this call.</returns>
-        public Helm WithKubeConfig(string configPath)
+        public IHelm WithKubeConfig(string configPath)
         {
             if(this.State.TryGetValue("hasKubeConfig", out object hasKubeConfig) && (bool)hasKubeConfig)
                 throw new InvalidOperationException($"{nameof(WithKubeConfig)} can only be called once per execution context.");
             
-            return this.WithArgument($"--kubeconfig={configPath}").WithState("hasKubeConfig", true);
+            return this.WithState("hasKubeConfig", true).WithArgument($"--kubeconfig={configPath}") as IHelm;
         }
     }
 }

--- a/src/Core/Implementations/Executables/Sleep.cs
+++ b/src/Core/Implementations/Executables/Sleep.cs
@@ -4,15 +4,24 @@ using Sheller.Models;
 namespace Sheller.Implementations.Executables
 {
     /// <summary>
+    /// The interface for `sleep`.
+    /// </summary>
+    public interface ISleep : IExecutable {}
+
+    /// <summary>
     /// The executable type for `sleep`.
     /// </summary>
-    public class Sleep : Executable<Sleep>
+    public class Sleep : Executable<ISleep>, ISleep
     {
         /// <summary>
-        /// Initializes this instance with the provided shell.
+        /// Creates a new instance of the <see cref="Sleep"/> type.
         /// </summary>
-        /// <param name="shell">The shell in which the executable should run.</param>
-        /// <returns>This instance.</returns>
-        public override Sleep Initialize(IShell shell) => this.Initialize("sleep", shell);
+        /// <returns>The instance.</returns>
+        protected override Executable<ISleep> Create() => new Sleep();
+
+        /// <summary>
+        /// The <cref see="Sleep"/> constructor.
+        /// </summary>
+        public Sleep() : base("sleep") {}
     }
 }

--- a/src/Core/Implementations/Shells/Bash.cs
+++ b/src/Core/Implementations/Shells/Bash.cs
@@ -1,17 +1,28 @@
 using System.Linq;
+using Sheller.Models;
 
 namespace Sheller.Implementations.Shells
 {
     /// <summary>
+    /// The shell interface for `bash`.
+    /// </summary>
+    public interface IBash : IShell<IBash> {}
+
+    /// <summary>
     /// The shell type for `bash`.
     /// </summary>
-    public class Bash : Shell<Bash>
+    public class Bash : Shell<IBash>, IBash
     {
         /// <summary>
-        /// Instantiates a <see cref="Bash"/> instance.
+        /// Creates a new instance of the <see cref="Bash"/> type.
         /// </summary>
         /// <returns>The instance.</returns>
-        public override Bash Initialize() => Initialize("bash");
+        protected override Shell<IBash> Create() => new Bash();
+
+        /// <summary>
+        /// The <cref see="Bash"/> constructor.
+        /// </summary>
+        public Bash() : base("bash") {}
 
         /// <summary>
         /// Builds the arguments that should be passed to the shell based on the shell's type.

--- a/src/Core/Implementations/Shells/Bash.cs
+++ b/src/Core/Implementations/Shells/Bash.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Sheller.Implementations.Executables;
 using Sheller.Models;
 
 namespace Sheller.Implementations.Shells
@@ -6,7 +12,7 @@ namespace Sheller.Implementations.Shells
     /// <summary>
     /// The shell interface for `bash`.
     /// </summary>
-    public interface IBash : IShell<IBash> {}
+    public interface IBash : IShell {}
 
     /// <summary>
     /// The shell type for `bash`.

--- a/src/Core/Implementations/Shells/Cmd.cs
+++ b/src/Core/Implementations/Shells/Cmd.cs
@@ -7,7 +7,7 @@ namespace Sheller.Implementations.Shells
     /// <summary>
     /// The interface for a generic shell.  Note: this assumes the shell is *nixy.
     /// </summary>
-    public interface ICmd : IShell<ICmd> {}
+    public interface ICmd : IShell {}
 
     /// <summary>
     /// The shell type for `cmd.exe`.

--- a/src/Core/Implementations/Shells/Cmd.cs
+++ b/src/Core/Implementations/Shells/Cmd.cs
@@ -1,18 +1,29 @@
 using System;
 using System.Linq;
+using Sheller.Models;
 
 namespace Sheller.Implementations.Shells
 {
     /// <summary>
+    /// The interface for a generic shell.  Note: this assumes the shell is *nixy.
+    /// </summary>
+    public interface ICmd : IShell<ICmd> {}
+
+    /// <summary>
     /// The shell type for `cmd.exe`.
     /// </summary>
-    public class Cmd : Shell<Cmd>
+    public class Cmd : Shell<ICmd>, ICmd
     {
         /// <summary>
-        /// Instantiates a <see cref="Bash"/> instance.
+        /// Creates a new instance of the <see cref="Cmd"/> type.
         /// </summary>
         /// <returns>The instance.</returns>
-        public override Cmd Initialize() => Initialize("cmd.exe");
+        protected override Shell<ICmd> Create() => new Cmd();
+
+        /// <summary>
+        /// The <cref see="Cmd"/> constructor.
+        /// </summary>
+        public Cmd() : base("cmd.exe") {}
 
         /// <summary>
         /// Builds the arguments that should be passed to the shell based on the shell's type.

--- a/src/Core/Implementations/Shells/GenericShell.cs
+++ b/src/Core/Implementations/Shells/GenericShell.cs
@@ -7,7 +7,7 @@ namespace Sheller.Implementations.Shells
     /// <summary>
     /// The interface for a generic shell.  Note: this assumes the shell is *nixy.
     /// </summary>
-    public interface IGenericShell : IShell<IGenericShell> {}
+    public interface IGenericShell : IShell {}
 
     /// <summary>
     /// The type for a generic shell.  Note: this assumes the shell is *nixy.

--- a/src/Core/Implementations/Shells/GenericShell.cs
+++ b/src/Core/Implementations/Shells/GenericShell.cs
@@ -10,7 +10,7 @@ namespace Sheller.Implementations.Shells
     public interface IGenericShell : IShell {}
 
     /// <summary>
-    /// The type for a generic shell.  Note: this assumes the shell is *nixy.
+    /// The type for a generic shell.
     /// </summary>
     public class GenericShell : Shell<IGenericShell>, IGenericShell
     {

--- a/src/Core/Implementations/Shells/GenericShell.cs
+++ b/src/Core/Implementations/Shells/GenericShell.cs
@@ -18,7 +18,7 @@ namespace Sheller.Implementations.Shells
         /// Creates a new instance of the <see cref="GenericShell"/> type.
         /// </summary>
         /// <returns>The instance.</returns>
-        protected override Shell<IGenericShell> Create() => new GenericShell(null);
+        protected override Shell<IGenericShell> Create() => new GenericShell(this.Path);
 
         /// <summary>
         /// <cref see="GenericShell"/> is a special case that cannot be initialized without a shell name.

--- a/src/Core/Implementations/Shells/GenericShell.cs
+++ b/src/Core/Implementations/Shells/GenericShell.cs
@@ -1,13 +1,31 @@
 
 using System.Linq;
+using Sheller.Models;
 
 namespace Sheller.Implementations.Shells
 {
     /// <summary>
-    /// The executable type for a generic shell.  Note: this assumes the shell is *nixy.
+    /// The interface for a generic shell.  Note: this assumes the shell is *nixy.
     /// </summary>
-    public class GenericShell : ShellBase<GenericShell>
+    public interface IGenericShell : IShell<IGenericShell> {}
+
+    /// <summary>
+    /// The type for a generic shell.  Note: this assumes the shell is *nixy.
+    /// </summary>
+    public class GenericShell : Shell<IGenericShell>, IGenericShell
     {
+        /// <summary>
+        /// Creates a new instance of the <see cref="GenericShell"/> type.
+        /// </summary>
+        /// <returns>The instance.</returns>
+        protected override Shell<IGenericShell> Create() => new GenericShell(null);
+
+        /// <summary>
+        /// <cref see="GenericShell"/> is a special case that cannot be initialized without a shell name.
+        /// </summary>
+        /// <param name="shell">The name or path of the shell.</param>       
+        public GenericShell(string shell) : base(shell) {}
+
         /// <summary>
         /// Builds the arguments that should be passed to the shell based on the shell's type.
         /// </summary>

--- a/src/Core/Implementations/Shells/Shell.cs
+++ b/src/Core/Implementations/Shells/Shell.cs
@@ -13,8 +13,8 @@ namespace Sheller.Implementations.Shells
     /// <summary>
     /// The implementation base class for shells.
     /// </summary>
-    /// <typeparam name="TShell">The type of the shell class implementing this interface.</typeparam>
-    public abstract class Shell<TShell> : IShell<TShell> where TShell : IShell
+    /// <typeparam name="TIShell">The type of the shell interface implementing this interface.</typeparam>
+    public abstract class Shell<TIShell> : IShell<TIShell> where TIShell : IShell
     {
         private string _shell;
 
@@ -46,19 +46,16 @@ namespace Sheller.Implementations.Shells
         public IEnumerable<KeyValuePair<string, string>> EnvironmentVariables => _environmentVariables;
 
         /// <summary>
-        /// Allows an implementer of <see cref="Shell{TShell}"/>
-        /// </summary>
-        /// <returns></returns>
-        protected abstract Shell<TShell> Create();
-
-        /// <summary>
         /// The <cref see="Shell"/> constructor.
         /// </summary>
         /// <param name="shell">The name or path of the shell.</param>        
-        public Shell(string shell)
-        {
-            this.Initialize(shell);
-        }
+        public Shell(string shell) => this.Initialize(shell);
+
+        /// <summary>
+        /// Allows an implementer of <see cref="Shell{TIShell}"/>
+        /// </summary>
+        /// <returns></returns>
+        protected abstract Shell<TIShell> Create();
 
         /// <summary>
         /// Initializes the shell.
@@ -95,7 +92,7 @@ namespace Sheller.Implementations.Shells
             string commandPrefix,
             bool? throws)
         {
-            _shell = shell;
+            _shell = shell ?? throw new InvalidOperationException("This shell definition does not define a shell.");;
 
             _environmentVariables = environmentVariables ?? new Dictionary<string, string>();
 
@@ -117,8 +114,8 @@ namespace Sheller.Implementations.Shells
             return this;
         }
 
-        private static TShell CreateFrom(
-            Shell<TShell> old,
+        private static TIShell CreateFrom(
+            Shell<TIShell> old,
             string shell = null, 
             IEnumerable<KeyValuePair<string, string>> environmentVariables = null,
             IEnumerable<string> standardInputs = null,
@@ -131,7 +128,7 @@ namespace Sheller.Implementations.Shells
             IEnumerable<CancellationToken> cancellationTokens = null,
             string commandPrefix = null,
             bool? throws = null) =>
-                (TShell)old.Create().Initialize(
+                (TIShell)old.Create().Initialize(
                     shell ?? old._shell,
                     environmentVariables ?? old._environmentVariables,
                     standardInputs ?? old._standardInputs,
@@ -189,8 +186,8 @@ namespace Sheller.Implementations.Shells
         /// <summary>
         /// Clones this instance.
         /// </summary>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the same settings as the invoking instance.</returns>
-        public virtual TShell Clone() => CreateFrom(this);
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the same settings as the invoking instance.</returns>
+        public virtual TIShell Clone() => CreateFrom(this);
         IShell IShell.Clone() => Clone();
 
         /// <summary>
@@ -198,48 +195,48 @@ namespace Sheller.Implementations.Shells
         /// </summary>
         /// <param name="key">The environment variable key.</param>
         /// <param name="value">The environment variable value.</param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the environment variable passed in this call.</returns>
-        public virtual TShell WithEnvironmentVariable(string key, string value) => CreateFrom(this, environmentVariables: Helpers.MergeEnumerables(_environmentVariables, new KeyValuePair<string, string>(key, value).ToEnumerable()));
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the environment variable passed in this call.</returns>
+        public virtual TIShell WithEnvironmentVariable(string key, string value) => CreateFrom(this, environmentVariables: Helpers.MergeEnumerables(_environmentVariables, new KeyValuePair<string, string>(key, value).ToEnumerable()));
         IShell IShell.WithEnvironmentVariable(string key, string value) => WithEnvironmentVariable(key, value);
                 
         /// <summary>
         /// Adds a list of environment variables (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="variables">The list of key value pairs of environment variables.</param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the environment variables passed in this call.</returns>
-        public virtual TShell WithEnvironmentVariables(IEnumerable<KeyValuePair<string, string>> variables) => CreateFrom(this, environmentVariables: Helpers.MergeEnumerables(_environmentVariables, variables));
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the environment variables passed in this call.</returns>
+        public virtual TIShell WithEnvironmentVariables(IEnumerable<KeyValuePair<string, string>> variables) => CreateFrom(this, environmentVariables: Helpers.MergeEnumerables(_environmentVariables, variables));
         IShell IShell.WithEnvironmentVariables(IEnumerable<KeyValuePair<string, string>> variables) => WithEnvironmentVariables(variables);
 
         /// <summary>
         /// Adds a list of environment variables (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="variables">The list of tuple of environment variables.</param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the environment variables passed in this call.</returns>
-        public virtual TShell WithEnvironmentVariables(IEnumerable<(string, string)> variables) => CreateFrom(this, environmentVariables: Helpers.MergeEnumerables(_environmentVariables, variables.ToDictionary()));
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the environment variables passed in this call.</returns>
+        public virtual TIShell WithEnvironmentVariables(IEnumerable<(string, string)> variables) => CreateFrom(this, environmentVariables: Helpers.MergeEnumerables(_environmentVariables, variables.ToDictionary()));
         IShell IShell.WithEnvironmentVariables(IEnumerable<(string, string)> variables) => WithEnvironmentVariables(variables);
 
         /// <summary>
         /// Adds a string to the standard input stream (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardInput">A string that gets passed to the standard input stram of the executable.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the standard input passed to this call.</returns>
-        public TShell WithStandardInput(string standardInput) => CreateFrom(this, standardInputs: Helpers.MergeEnumerables(_standardInputs, standardInput.ToEnumerable()));
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the standard input passed to this call.</returns>
+        public TIShell WithStandardInput(string standardInput) => CreateFrom(this, standardInputs: Helpers.MergeEnumerables(_standardInputs, standardInput.ToEnumerable()));
         IShell IShell.WithStandardInput(string standardInput) => WithStandardInput(standardInput);
 
         /// <summary>
         /// Adds a standard output handler (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardOutputHandler">An <see cref="Action"/> that handles a new line in the standard output of the executable.</param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the standard output handler passed to this call.</returns>
-        public virtual TShell WithStandardOutputHandler(Action<string> standardOutputHandler) => CreateFrom(this, standardOutputHandlers: Helpers.MergeEnumerables(_standardOutputHandlers, standardOutputHandler.ToEnumerable()));
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the standard output handler passed to this call.</returns>
+        public virtual TIShell WithStandardOutputHandler(Action<string> standardOutputHandler) => CreateFrom(this, standardOutputHandlers: Helpers.MergeEnumerables(_standardOutputHandlers, standardOutputHandler.ToEnumerable()));
         IShell IShell.WithStandardOutputHandler(Action<string> standardOutputHandler) => WithStandardOutputHandler(standardOutputHandler);
 
         /// <summary>
         /// Adds an error output handler (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardErrorHandler">An <see cref="Action"/> that handles a new line in the standard error of the executable.</param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the standard error handler passed to this call.</returns>
-        public virtual TShell WithStandardErrorHandler(Action<string> standardErrorHandler) => CreateFrom(this, standardErrorHandlers: Helpers.MergeEnumerables(_standardErrorHandlers, standardErrorHandler.ToEnumerable()));
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the standard error handler passed to this call.</returns>
+        public virtual TIShell WithStandardErrorHandler(Action<string> standardErrorHandler) => CreateFrom(this, standardErrorHandlers: Helpers.MergeEnumerables(_standardErrorHandlers, standardErrorHandler.ToEnumerable()));
         IShell IShell.WithStandardErrorHandler(Action<string> standardErrorHandler) => WithStandardErrorHandler(standardErrorHandler);
 
         /// <summary>
@@ -250,32 +247,32 @@ namespace Sheller.Implementations.Shells
         /// This handler should take (string StandardOutput, string StandardInput) and return a <see cref="Task{String}"/>
         /// that will be passed to the executable as StandardInput.
         /// </param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the standard error handler passed to this call.</returns>
-        public TShell UseInputRequestHandler(Func<string, string, Task<string>> inputRequestHandler) => CreateFrom(this, inputRequestHandler: inputRequestHandler);
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the standard error handler passed to this call.</returns>
+        public TIShell UseInputRequestHandler(Func<string, string, Task<string>> inputRequestHandler) => CreateFrom(this, inputRequestHandler: inputRequestHandler);
         IShell IShell.UseInputRequestHandler(Func<string, string, Task<string>> inputRequestHandler) => UseInputRequestHandler(inputRequestHandler);
 
         /// <summary>
         /// Set the Standard Output Encoding on the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardOutputEncoding">The encoding to use for standard output.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the standard output encoding passed to this call.</returns>
-        public TShell UseStandardOutputEncoding(Encoding standardOutputEncoding) => CreateFrom(this, standardOutputEncoding: standardOutputEncoding);
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the standard output encoding passed to this call.</returns>
+        public TIShell UseStandardOutputEncoding(Encoding standardOutputEncoding) => CreateFrom(this, standardOutputEncoding: standardOutputEncoding);
         IShell IShell.UseStandardOutputEncoding(Encoding standardOutputEncoding) => UseStandardOutputEncoding(standardOutputEncoding);
 
         /// <summary>
         /// Set the Standard Error Encoding on the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardErrorEncoding">The encoding to use for standard error.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the standard error encoding passed to this call.</returns>
-        public TShell UseStandardErrorEncoding(Encoding standardErrorEncoding) => CreateFrom(this, standardErrorEncoding: standardErrorEncoding);
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the standard error encoding passed to this call.</returns>
+        public TIShell UseStandardErrorEncoding(Encoding standardErrorEncoding) => CreateFrom(this, standardErrorEncoding: standardErrorEncoding);
         IShell IShell.UseStandardErrorEncoding(Encoding standardErrorEncoding) => UseStandardErrorEncoding(standardErrorEncoding);
 
         /// <summary>
         /// Provides an <see cref="IObservable{T}"/> to which a subscription can be placed.
         /// The observable never completes, since executions can be run many times.
         /// </summary>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the subscribers attached to the observable.</returns>
-        public TShell WithSubscribe(Action<IObservable<ICommandEvent>> subscriber)
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the subscribers attached to the observable.</returns>
+        public TIShell WithSubscribe(Action<IObservable<ICommandEvent>> subscriber)
         {
             var newObservable = new ObservableCommandEvent();
             subscriber(newObservable);
@@ -286,23 +283,23 @@ namespace Sheller.Implementations.Shells
         /// <summary>
         /// Adds a <see cref="CancellationToken"/> (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the cancellation token attached.</returns>
-        public TShell WithCancellationToken(CancellationToken cancellationToken) => CreateFrom(this, cancellationTokens: Helpers.MergeEnumerables(_cancellationTokens, cancellationToken.ToEnumerable()));
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the cancellation token attached.</returns>
+        public TIShell WithCancellationToken(CancellationToken cancellationToken) => CreateFrom(this, cancellationTokens: Helpers.MergeEnumerables(_cancellationTokens, cancellationToken.ToEnumerable()));
         IShell IShell.WithCancellationToken(CancellationToken cancellationToken) => WithCancellationToken(cancellationToken);
 
         /// <summary>
         /// Set a "prefix" string for all commands executed on the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="prefix">The prefix for all commands.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the prefix string passed to this call.</returns>
-        public TShell UseCommandPrefix(string prefix) => CreateFrom(this, commandPrefix: prefix);
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the prefix string passed to this call.</returns>
+        public TIShell UseCommandPrefix(string prefix) => CreateFrom(this, commandPrefix: prefix);
         IShell IShell.UseCommandPrefix(string prefix) => UseCommandPrefix(prefix);
 
         /// <summary>
         /// Ensures the shell context will not throw on a non-zero exit code and returns a `new` context instance.
         /// </summary>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> that will not throw on a non-zero exit code.</returns>
-        public TShell UseNoThrow() => CreateFrom(this, throws: false);
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> that will not throw on a non-zero exit code.</returns>
+        public TIShell UseNoThrow() => CreateFrom(this, throws: false);
         IShell IShell.UseNoThrow() => UseNoThrow();
 
         /// <summary>
@@ -310,14 +307,14 @@ namespace Sheller.Implementations.Shells
         /// </summary>
         /// <typeparam name="TExecutable">The type of the executable to use.</typeparam>
         /// <returns>An instance of <typeparamref name="TExecutable"/> passed to this call.</returns>
-        public virtual TExecutable UseExecutable<TExecutable>() where TExecutable : Executable<TExecutable>, new() => new TExecutable().Initialize(this);
+        public virtual TExecutable UseExecutable<TExecutable>() where TExecutable : IExecutable, new() => (TExecutable)new TExecutable().UseShell(this);
 
         /// <summary>
         /// Adds an executable and switches to the executable context.
         /// </summary>
         /// <param name="exe">The name or path of the executable.</param>
         /// <returns>An instance of <see cref="GenericExe"/> which represents the executable name or path passed to this call.</returns>
-        public virtual GenericExe UseExecutable(string exe) => new GenericExe().Initialize(exe, this);
+        public virtual IExecutable UseExecutable(string exe) => new GenericExe(exe).UseShell(this);
 
         /// <summary>
         /// Builds the arguments that should be passed to the shell based on the shell's type.

--- a/src/Core/Implementations/Shells/Shell.cs
+++ b/src/Core/Implementations/Shells/Shell.cs
@@ -14,7 +14,7 @@ namespace Sheller.Implementations.Shells
     /// The implementation base class for shells.
     /// </summary>
     /// <typeparam name="TShell">The type of the shell class implementing this interface.</typeparam>
-    public abstract class Shell<TShell> : IShell<TShell> where TShell : IShell<TShell>
+    public abstract class Shell<TShell> : IShell<TShell> where TShell : IShell
     {
         private string _shell;
 
@@ -46,12 +46,6 @@ namespace Sheller.Implementations.Shells
         public IEnumerable<KeyValuePair<string, string>> EnvironmentVariables => _environmentVariables;
 
         /// <summary>
-        /// Allows a <see cref="Shell{TShell}"/> to be implicitly convertible to <typeparamref name="TShell"/>.
-        /// </summary>
-        /// <param name="shell">The concrete <see cref="Shell{TShell}"/>.</param>
-        public static implicit operator TShell(Shell<TShell> shell) => (TShell)shell;
-
-        /// <summary>
         /// Allows an implementer of <see cref="Shell{TShell}"/>
         /// </summary>
         /// <returns></returns>
@@ -63,14 +57,14 @@ namespace Sheller.Implementations.Shells
         /// <param name="shell">The name or path of the shell.</param>        
         public Shell(string shell)
         {
-            _shell = shell;
+            this.Initialize(shell);
         }
 
         /// <summary>
         /// Initializes the shell.
         /// </summary>
         /// <param name="shell">The name or path of the shell.</param>
-        //public virtual TShell Initialize(string shell) => Initialize(shell, null, null, null, null, null, null, null, null, null, null, null);
+        private IShell Initialize(string shell) => Initialize(shell, null, null, null, null, null, null, null, null, null, null, null);
 
         /// <summary>
         /// Initializes the shell.
@@ -87,7 +81,7 @@ namespace Sheller.Implementations.Shells
         /// <param name="cancellationTokens">The cancellation tokens for cancelling executions.</param>
         /// <param name="commandPrefix">The command prefix for all commands executed with this shell.</param>
         /// <param name="throws">Indicates that a non-zero exit code throws.</param>
-        private TShell Initialize(
+        private IShell Initialize(
             string shell, 
             IEnumerable<KeyValuePair<string, string>> environmentVariables,
             IEnumerable<string> standardInputs,
@@ -137,7 +131,7 @@ namespace Sheller.Implementations.Shells
             IEnumerable<CancellationToken> cancellationTokens = null,
             string commandPrefix = null,
             bool? throws = null) =>
-                old.Create().Initialize(
+                (TShell)old.Create().Initialize(
                     shell ?? old._shell,
                     environmentVariables ?? old._environmentVariables,
                     standardInputs ?? old._standardInputs,

--- a/src/Core/Models/IExecutable.cs
+++ b/src/Core/Models/IExecutable.cs
@@ -142,62 +142,62 @@ namespace Sheller.Models
     /// <summary>
     /// A top-level interface for executables.
     /// </summary>
-    /// <typeparam name="TExecutable">The type of the executable class implementing this interface.  This allows the base class to return `new` instances for daisy chaining.</typeparam>
-    public interface IExecutable<out TExecutable> : IExecutable where TExecutable : IExecutable<TExecutable>
+    /// <typeparam name="TIExecutable">The type of the executable class implementing this interface.  This allows the base class to return `new` instances for daisy chaining.</typeparam>
+    public interface IExecutable<out TIExecutable> : IExecutable where TIExecutable : IExecutable
     {
         /// <summary>
         /// Clones this instance.
         /// </summary>
-        /// <returns>A `new` instance of <typeparamref name="TExecutable"/> with the same settings as the invoking instance.</returns>
-        new TExecutable Clone();
+        /// <returns>A `new` instance of <typeparamref name="TIExecutable"/> with the same settings as the invoking instance.</returns>
+        new TIExecutable Clone();
 
         /// <summary>
         /// Changes the shell of the execution context and returns a `new` context instance.
         /// </summary>
         /// <param name="shell">The new <see cref="IShell"/> to use.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TExecutable"/> with the arguments passed to this call.</returns>
-        new TExecutable UseShell(IShell shell);
+        /// <returns>A `new` instance of type <typeparamref name="TIExecutable"/> with the arguments passed to this call.</returns>
+        new TIExecutable UseShell(IShell shell);
 
         /// <summary>
         /// Changes the executable of the execution context and returns a `new` context instance.
         /// This should be used sparingly for very specific use cases (e.g., you renamed `kubectl` to `k`, and you need to reflect that).
         /// </summary>
         /// <param name="executable">The new executable to use.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TExecutable"/> with the arguments passed to this call.</returns>
-        new TExecutable UseExecutable(string executable);
+        /// <returns>A `new` instance of type <typeparamref name="TIExecutable"/> with the arguments passed to this call.</returns>
+        new TIExecutable UseExecutable(string executable);
 
         /// <summary>
         /// Adds an argument (which are appended space-separated to the execution command) to the execution context and returns a `new` context instance.
         /// </summary>
         /// <param name="args">An arbitrary list of strings to be added as parameters.</param>
-        /// <returns>A `new` instance of <typeparamref name="TExecutable"/> with the arguments passed to this call.</returns>
-        new TExecutable WithArgument(params string[] args);
+        /// <returns>A `new` instance of <typeparamref name="TIExecutable"/> with the arguments passed to this call.</returns>
+        new TIExecutable WithArgument(params string[] args);
 
         /// <summary>
         /// Sets the timeout on the entire execution of this entire execution context.
         /// </summary>
         /// <param name="timeout">The timeout.</param>
-        /// <returns>A `new` instance of <typeparamref name="TExecutable"/> with the timeout set to the value passed to this call.</returns>
-        new TExecutable UseTimeout(TimeSpan timeout);
+        /// <returns>A `new` instance of <typeparamref name="TIExecutable"/> with the timeout set to the value passed to this call.</returns>
+        new TIExecutable UseTimeout(TimeSpan timeout);
 
         /// <summary>
         /// Adds a string to the standard input stream (of which there may be many) to the executable context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardInput">A string that gets passed to the standard input stream of the executable.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TExecutable"/> with the standard input passed to this call.</returns>
-        new TExecutable WithStandardInput(string standardInput);
+        /// <returns>A `new` instance of type <typeparamref name="TIExecutable"/> with the standard input passed to this call.</returns>
+        new TIExecutable WithStandardInput(string standardInput);
         /// <summary>
         /// Adds a standard output handler (of which there may be many) to the execution context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardOutputHandler">An <see cref="Action"/> that handles a new line in the standard output of the executable.</param>
-        /// <returns>A `new` instance of <typeparamref name="TExecutable"/> with the standard output handler passed to this call.</returns>
-        new TExecutable WithStandardOutputHandler(Action<string> standardOutputHandler);
+        /// <returns>A `new` instance of <typeparamref name="TIExecutable"/> with the standard output handler passed to this call.</returns>
+        new TIExecutable WithStandardOutputHandler(Action<string> standardOutputHandler);
         /// <summary>
         /// Adds an error output handler (of which there may be many) to the execution context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardErrorHandler">An <see cref="Action"/> that handles a new line in the standard error of the executable.</param>
-        /// <returns>A `new` instance of <typeparamref name="TExecutable"/> with the standard error handler passed to this call.</returns>
-        new TExecutable WithStandardErrorHandler(Action<string> standardErrorHandler);
+        /// <returns>A `new` instance of <typeparamref name="TIExecutable"/> with the standard error handler passed to this call.</returns>
+        new TIExecutable WithStandardErrorHandler(Action<string> standardErrorHandler);
         /// <summary>
         /// Adds a (user) input request handler to the execution context and returns a `new` context instance.
         /// </summary>
@@ -206,60 +206,60 @@ namespace Sheller.Models
         /// This handler should take (string StandardOutput, string StandardInput) and return a <see cref="Task{String}"/>
         /// that will be passed to the executable as StandardInput.
         /// </param>
-        /// <returns>A `new` instance of <typeparamref name="TExecutable"/> with the request handler passed to this call.</returns>
-        new TExecutable UseInputRequestHandler(Func<string, string, Task<string>> inputRequestHandler);
+        /// <returns>A `new` instance of <typeparamref name="TIExecutable"/> with the request handler passed to this call.</returns>
+        new TIExecutable UseInputRequestHandler(Func<string, string, Task<string>> inputRequestHandler);
         /// <summary>
         /// Set the Standard Output Encoding on the execution context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardOutputEncoding">The encoding to use for standard output.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TExecutable"/> with the standard output encoding passed to this call.</returns>
-        new TExecutable UseStandardOutputEncoding(Encoding standardOutputEncoding);
+        /// <returns>A `new` instance of type <typeparamref name="TIExecutable"/> with the standard output encoding passed to this call.</returns>
+        new TIExecutable UseStandardOutputEncoding(Encoding standardOutputEncoding);
         /// <summary>
         /// Set the Standard Error Encoding on the execution context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardErrorEncoding">The encoding to use for standard error.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TExecutable"/> with the standard error encoding passed to this call.</returns>
-        new TExecutable UseStandardErrorEncoding(Encoding standardErrorEncoding);
+        /// <returns>A `new` instance of type <typeparamref name="TIExecutable"/> with the standard error encoding passed to this call.</returns>
+        new TIExecutable UseStandardErrorEncoding(Encoding standardErrorEncoding);
 
         /// <summary>
         /// Provides an <see cref="IObservable{T}"/> to which a subscription can be placed.
         /// The observable never completes, since executions can be run many times.
         /// </summary>
-        /// <returns>A `new` instance of type <typeparamref name="TExecutable"/> with the subscribers attached to the observable.</returns>
-        new TExecutable WithSubscribe(Action<IObservable<ICommandEvent>> subscriber);
+        /// <returns>A `new` instance of type <typeparamref name="TIExecutable"/> with the subscribers attached to the observable.</returns>
+        new TIExecutable WithSubscribe(Action<IObservable<ICommandEvent>> subscriber);
 
         /// <summary>
         /// Adds a <see cref="CancellationToken"/> (of which there may be many) to the execution context and returns a `new` context instance.
         /// </summary>
-        /// <returns>A `new` instance of type <typeparamref name="TExecutable"/> with the cancellation token attached.</returns>
-        new TExecutable WithCancellationToken(CancellationToken cancellationToken);
+        /// <returns>A `new` instance of type <typeparamref name="TIExecutable"/> with the cancellation token attached.</returns>
+        new TIExecutable WithCancellationToken(CancellationToken cancellationToken);
 
         /// <summary>
         /// Adds a wait <see cref="Func{T}"/> (of which there may be many) to the execution context and returns a `new` context instance.
         /// </summary>
         /// <param name="waitFunc">A <see cref="Func{T}"/> which takes an <see cref="ICommandResult"/> and returns a <see cref="Task"/> which will function as wait condition upon the completion of execution.</param>
-        /// <returns>A `new` instance of <typeparamref name="TExecutable"/> with the wait func passed to this call.</returns>
-        new TExecutable WithWait(Func<ICommandResult, Task> waitFunc);
+        /// <returns>A `new` instance of <typeparamref name="TIExecutable"/> with the wait func passed to this call.</returns>
+        new TIExecutable WithWait(Func<ICommandResult, Task> waitFunc);
         /// <summary>
         /// Sets the wait timeout on the <see cref="WithWait"/> <see cref="Func{T}"/>.
         /// </summary>
         /// <param name="timeout">The timeout.</param>
-        /// <returns>A `new` instance of <typeparamref name="TExecutable"/> with the wait timeout set to the value passed to this call.</returns>
-        new TExecutable UseWaitTimeout(TimeSpan timeout);
+        /// <returns>A `new` instance of <typeparamref name="TIExecutable"/> with the wait timeout set to the value passed to this call.</returns>
+        new TIExecutable UseWaitTimeout(TimeSpan timeout);
 
         /// <summary>
         /// Ensures the execution context will not throw on a non-zero exit code and returns a `new` context instance.
         /// </summary>
-        /// <returns>A `new` instance of type <typeparamref name="TExecutable"/> that will not throw on a non-zero exit code.</returns>
-        new TExecutable UseNoThrow();
+        /// <returns>A `new` instance of type <typeparamref name="TIExecutable"/> that will not throw on a non-zero exit code.</returns>
+        new TIExecutable UseNoThrow();
     }
 
     /// <summary>
     /// An interface for executables that define the execute method with a special result type.
     /// </summary>
-    /// <typeparam name="TExecutable">The type of the executable class implementing this interface.  This allows the base class to return `new` instances for daisy chaining.</typeparam>
+    /// <typeparam name="TIExecutable">The type of the executable class implementing this interface.  This allows the base class to return `new` instances for daisy chaining.</typeparam>
     /// <typeparam name="TResult">The result type of the executable.</typeparam>
-    public interface IExecutable<out TExecutable, TResult> : IExecutable<TExecutable> where TExecutable : IExecutable<TExecutable>
+    public interface IExecutable<out TIExecutable, TResult> : IExecutable<TIExecutable> where TIExecutable : IExecutable
     {
         /// <summary>
         /// Executes the executable.

--- a/src/Core/Models/IShell.cs
+++ b/src/Core/Models/IShell.cs
@@ -118,13 +118,13 @@ namespace Sheller.Models
         /// </summary>
         /// <typeparam name="TExecutable">The type of the executable to use.</typeparam>
         /// <returns>An instance of <typeparamref name="TExecutable"/> passed to this call.</returns>
-        TExecutable UseExecutable<TExecutable>() where TExecutable : Executable<TExecutable>, new();
+        TExecutable UseExecutable<TExecutable>() where TExecutable : IExecutable, new();
         /// <summary>
         /// Adds an executable and switches to the executable context.
         /// </summary>
         /// <param name="exe">The name or path of the executable.</param>
         /// <returns>An instance of <see cref="GenericExe"/> which represents the executable name or path passed to this call.</returns>
-        GenericExe UseExecutable(string exe);
+        IExecutable UseExecutable(string exe);
         
         /// <summary>
         /// Builds the arguments that should be passed to the shell based on the shell's type.
@@ -137,53 +137,53 @@ namespace Sheller.Models
     /// <summary>
     /// The interface for defining a shell.
     /// </summary>
-    /// <typeparam name="TShell">The type of the shell class implementing this interface.  This allows the base class to return `new` instances for daisy chaining.</typeparam>
-    public interface IShell<out TShell> : IShell where TShell : IShell
+    /// <typeparam name="TIShell">The type of the shell class implementing this interface.  This allows the base class to return `new` instances for daisy chaining.</typeparam>
+    public interface IShell<out TIShell> : IShell where TIShell : IShell
     {
         /// <summary>
         /// Clones this instance.
         /// </summary>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the same settings as the invoking instance.</returns>
-        new TShell Clone();
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the same settings as the invoking instance.</returns>
+        new TIShell Clone();
 
         /// <summary>
         /// Adds an environment variable (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="key">The environment variable key.</param>
         /// <param name="value">The environment variable value.</param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the environment variable passed in this call.</returns>
-        new TShell WithEnvironmentVariable(string key, string value);
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the environment variable passed in this call.</returns>
+        new TIShell WithEnvironmentVariable(string key, string value);
         /// <summary>
         /// Adds a list of environment variables (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="variables">The list of key value pairs of environment variables.</param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the environment variables passed in this call.</returns>
-        new TShell WithEnvironmentVariables(IEnumerable<KeyValuePair<string, string>> variables);
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the environment variables passed in this call.</returns>
+        new TIShell WithEnvironmentVariables(IEnumerable<KeyValuePair<string, string>> variables);
         /// <summary>
         /// Adds a list of environment variables (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="variables">The list of tuple of environment variables.</param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the environment variables passed in this call.</returns>
-        new TShell WithEnvironmentVariables(IEnumerable<(string, string)> variables);
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the environment variables passed in this call.</returns>
+        new TIShell WithEnvironmentVariables(IEnumerable<(string, string)> variables);
 
         /// <summary>
         /// Adds a string to the standard input stream (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardInput">A string that gets passed to the standard input stream of the executable.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the standard input passed to this call.</returns>
-        new TShell WithStandardInput(string standardInput);
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the standard input passed to this call.</returns>
+        new TIShell WithStandardInput(string standardInput);
         /// <summary>
         /// Adds a standard output handler (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardOutputHandler">An <see cref="Action"/> that handles a new line in the standard output of the executable.</param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the standard output handler passed to this call.</returns>
-        new TShell WithStandardOutputHandler(Action<string> standardOutputHandler);
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the standard output handler passed to this call.</returns>
+        new TIShell WithStandardOutputHandler(Action<string> standardOutputHandler);
         /// <summary>
         /// Adds an error output handler (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardErrorHandler">An <see cref="Action"/> that handles a new line in the standard error of the executable.</param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the standard error handler passed to this call.</returns>
-        new TShell WithStandardErrorHandler(Action<string> standardErrorHandler);
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the standard error handler passed to this call.</returns>
+        new TIShell WithStandardErrorHandler(Action<string> standardErrorHandler);
         /// <summary>
         /// Adds a (user) input request handler to the shell context and returns a `new` context instance.
         /// </summary>
@@ -192,45 +192,45 @@ namespace Sheller.Models
         /// This handler should take (string StandardOutput, string StandardInput) and return a <see cref="Task{String}"/>
         /// that will be passed to the executable as StandardInput.
         /// </param>
-        /// <returns>A `new` instance of <typeparamref name="TShell"/> with the standard error handler passed to this call.</returns>
-        new TShell UseInputRequestHandler(Func<string, string, Task<string>> inputRequestHandler);
+        /// <returns>A `new` instance of <typeparamref name="TIShell"/> with the standard error handler passed to this call.</returns>
+        new TIShell UseInputRequestHandler(Func<string, string, Task<string>> inputRequestHandler);
         /// <summary>
         /// Set the Standard Output Encoding on the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardOutputEncoding">The encoding to use for standard output.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the standard output encoding passed to this call.</returns>
-        new TShell UseStandardOutputEncoding(Encoding standardOutputEncoding);
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the standard output encoding passed to this call.</returns>
+        new TIShell UseStandardOutputEncoding(Encoding standardOutputEncoding);
         /// <summary>
         /// Set the Standard Error Encoding on the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="standardErrorEncoding">The encoding to use for standard error.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the standard error encoding passed to this call.</returns>
-        new TShell UseStandardErrorEncoding(Encoding standardErrorEncoding);
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the standard error encoding passed to this call.</returns>
+        new TIShell UseStandardErrorEncoding(Encoding standardErrorEncoding);
 
         /// <summary>
         /// Provides an <see cref="IObservable{T}"/> to which a subscription can be placed.
         /// The observable never completes, since executions can be run many times.
         /// </summary>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the subscribers attached to the observable.</returns>
-        new TShell WithSubscribe(Action<IObservable<ICommandEvent>> subscriber);
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the subscribers attached to the observable.</returns>
+        new TIShell WithSubscribe(Action<IObservable<ICommandEvent>> subscriber);
 
         /// <summary>
         /// Adds a <see cref="CancellationToken"/> (of which there may be many) to the shell context and returns a `new` context instance.
         /// </summary>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the cancellation token attached.</returns>
-        new TShell WithCancellationToken(CancellationToken cancellationToken);
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the cancellation token attached.</returns>
+        new TIShell WithCancellationToken(CancellationToken cancellationToken);
 
         /// <summary>
         /// Set a "prefix" string for all commands executed on the shell context and returns a `new` context instance.
         /// </summary>
         /// <param name="prefix">The prefix for all commands.</param>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> with the prefix string passed to this call.</returns>
-        new TShell UseCommandPrefix(string prefix);
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> with the prefix string passed to this call.</returns>
+        new TIShell UseCommandPrefix(string prefix);
 
         /// <summary>
         /// Ensures the shell context will not throw on a non-zero exit code and returns a `new` context instance.
         /// </summary>
-        /// <returns>A `new` instance of type <typeparamref name="TShell"/> that will not throw on a non-zero exit code.</returns>
-        new TShell UseNoThrow();
+        /// <returns>A `new` instance of type <typeparamref name="TIShell"/> that will not throw on a non-zero exit code.</returns>
+        new TIShell UseNoThrow();
     }
 }

--- a/src/Core/Models/IShell.cs
+++ b/src/Core/Models/IShell.cs
@@ -138,7 +138,7 @@ namespace Sheller.Models
     /// The interface for defining a shell.
     /// </summary>
     /// <typeparam name="TShell">The type of the shell class implementing this interface.  This allows the base class to return `new` instances for daisy chaining.</typeparam>
-    public interface IShell<out TShell> : IShell where TShell : IShell<TShell>
+    public interface IShell<out TShell> : IShell where TShell : IShell
     {
         /// <summary>
         /// Clones this instance.

--- a/src/Core/Models/IShell.cs
+++ b/src/Core/Models/IShell.cs
@@ -116,9 +116,9 @@ namespace Sheller.Models
         /// <summary>
         /// Adds an executable and switches to the executable context.
         /// </summary>
-        /// <typeparam name="TExecutable">The type of the executable to use.</typeparam>
-        /// <returns>An instance of <typeparamref name="TExecutable"/> passed to this call.</returns>
-        TExecutable UseExecutable<TExecutable>() where TExecutable : IExecutable, new();
+        /// <typeparam name="TIExecutable">The type of the executable to use.</typeparam>
+        /// <returns>An instance of <typeparamref name="TIExecutable"/> passed to this call.</returns>
+        TIExecutable UseExecutable<TIExecutable>() where TIExecutable : IExecutable, new();
         /// <summary>
         /// Adds an executable and switches to the executable context.
         /// </summary>

--- a/src/Core/Sheller.cs
+++ b/src/Core/Sheller.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using Sheller.Implementations;
 using Sheller.Implementations.Shells;
@@ -19,13 +20,13 @@ namespace Sheller
         /// </summary>
         /// <param name="shell">The name or path of the shell.</param>
         /// <returns>The shell instance.</returns>
-        public static GenericShell UseShell(string shell) => new GenericShell().Initialize(shell);
+        public static IGenericShell UseShell(string shell) => new GenericShell(shell);
 
         /// <summary>
         /// Creates a new shell instance.
         /// </summary>
         /// <typeparam name="TShell">The type of the shell to instantiate.</typeparam>
         /// <returns>The shell instance.</returns>
-        public static TShell UseShell<TShell>() where TShell : Shell<TShell>, new() => new TShell().Initialize();
+        public static TShell UseShell<TShell>() where TShell : IShell, new() => new TShell();
     }
 }


### PR DESCRIPTION
With the exception of `UseShell` and `UseExecutable` methods, all methods now return the interface types.  In addition, custom shells and executables now implement interfaces.